### PR TITLE
Rename crate to stellar-contract-asset-spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stellar-asset-contract-spec"
+name = "stellar-contract-asset-spec"
 version = "0.0.0"
 dependencies = [
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stellar-asset-contract-spec"
+name = "stellar-contract-asset-spec"
 edition = "2021"
 version = "0.0.0"
 publish = false


### PR DESCRIPTION
### What
Rename package from stellar-asset-contract-spec to stellar-contract-asset-spec.

### Why
The binary generated by the crate would fit into the stellar-cli's plugin naming scheme. It's not particularly important because aren't intending to use it as a particularly popular plugin, I just thought may as well rename it so it fits and is more consistent.